### PR TITLE
Fix issue with old versions of pandoc on qsub

### DIFF
--- a/common/pigx-runner.in
+++ b/common/pigx-runner.in
@@ -433,7 +433,7 @@ if config['execution']['submit-to-cluster']:
         else:
             raise
 
-    qsub = "qsub -v R_LIBS_USER -v R_LIBS -v PIGX_PATH -v GUIX_LOCPATH %s -l h_stack={cluster.h_stack}  -l h_vmem={cluster.MEM} %s -b y -pe smp {cluster.nthreads} -cwd" % (queue_selection_string, contact_email_string)
+    qsub = "qsub -v R_LIBS_USER -v R_LIBS -v PIGX_PATH -v RSTUDIO_PANDOC -v GUIX_LOCPATH %s -l h_stack={cluster.h_stack}  -l h_vmem={cluster.MEM} %s -b y -pe smp {cluster.nthreads} -cwd" % (queue_selection_string, contact_email_string)
     if config['execution']['cluster']['log-dir']:
         qsub += " -o %s/ " % config['execution']['cluster']['log-dir']
         qsub += " -e %s/ " % config['execution']['cluster']['log-dir']

--- a/common/qsub-template.sh.in
+++ b/common/qsub-template.sh.in
@@ -4,7 +4,7 @@
 if [ 'yes' = '@capture_environment@' ]; then
     export R_LIBS_SITE="@R_LIBS_SITE@"
     export PYTHONPATH="@PYTHONPATH@"
-    export RSTUDIO_PANDOC=$(dirname "@PANDOC@")
+    export RSTUDIO_PANDOC="$(dirname @PANDOC@)"
 fi
 
 env

--- a/common/qsub-template.sh.in
+++ b/common/qsub-template.sh.in
@@ -4,6 +4,7 @@
 if [ 'yes' = '@capture_environment@' ]; then
     export R_LIBS_SITE="@R_LIBS_SITE@"
     export PYTHONPATH="@PYTHONPATH@"
+    export RSTUDIO_PANDOC=$(dirname "@PANDOC@")
 fi
 
 env


### PR DESCRIPTION
This addresses the following error:
```
Error: pandoc version 1.12.3 or higher is required and was not found (see the help page ?rmarkdown::pandoc_available).
```

Which has been extensively explored in PiGx-RNASeq (see https://github.com/BIMSBbioinfo/pigx_rnaseq/issues/137).

This fixes https://github.com/BIMSBbioinfo/pigx_rnaseq/issues/137. 